### PR TITLE
GHA: Add crystal-lib to build-cache

### DIFF
--- a/.github/workflows/test-crystal-shards.yml
+++ b/.github/workflows/test-crystal-shards.yml
@@ -103,6 +103,7 @@ jobs:
           path: |
             ./crystal/.build/crystal
             ./shards/bin/shards
+            ./crystal-lib
           key: ${{ runner.os }}-build-${{ hashFiles('./build-cache-key') }}
       - name: Build Crystal Deps
         run: |


### PR DESCRIPTION
`crystal-lib` was missing from `build-cache` and thus only available on cache miss.

We don't need to use a fresh cache key because `actions/cache` tracks the cached paths.

Workflow run: https://github.com/crystal-lang/test-ecosystem/actions/runs/1023909032 (the failing lucky spec is unrelated).

Resolves #2