### PR TITLE
Add compiler/interpreter implementation shards

### DIFF
--- a/bats/70-implementations.bats
+++ b/bats/70-implementations.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+@test "crinja specs" {
+  pushd $REPOS_DIR/straight-shoota/crinja
+  make test
+  popd
+}
+
+@test "mint specs" {
+  pushd $REPOS_DIR/mint-lang/mint
+  shards install
+  make test
+  popd
+}

--- a/scripts/10-clone-repos.sh
+++ b/scripts/10-clone-repos.sh
@@ -70,6 +70,9 @@ gh_clone amberframework/amber
 gh_clone amberframework/granite
 gh_clone TechMagister/liquid.cr
 
+gh_clone "straight-shoota/crinja"
+gh_clone "mint-lang/mint"
+
 cat $REPOS_DIR/shard.override.yml
 
 # Copy samples directory to $REPOS_DIR/samples


### PR DESCRIPTION
[crinja](https://github.com/straight-shoota/crinja) and [mint](https://github.com/mint-lang/mint/) are compiler/interpreter implementations in Crystal. Their code bases are relatively big and complex, so they are good candidates for ecosystem smoke tests to spot bugs with less commonly used code structures.

Crinja has already served as an indicator for compiler and stdlib bugs multiple times (it regularly runs CI against Crystal nightly). It makes sense to include them into our ecosystem test suite.