### PR TITLE
Add mercurial to install-tools for shards

### DIFF
--- a/scripts/apt-install-tools.sh
+++ b/scripts/apt-install-tools.sh
@@ -2,5 +2,5 @@
 
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get install -y git software-properties-common lsb-release curl wget \
+apt-get install -y git mercurial software-properties-common lsb-release curl wget \
                    ca-certificates apt-transport-https postgresql-client


### PR DESCRIPTION
Shards now has support for mercurial backend, so we need that installed to run the specs.

