### PR TITLE
Add shard override to pin crystal-db@0.10.1

### DIFF
--- a/scripts/10-clone-repos.sh
+++ b/scripts/10-clone-repos.sh
@@ -48,6 +48,8 @@ function gh_clone {
   fi
 }
 
+override_shard db crystal-lang/crystal-db v0.10.1
+
 gh_clone crystal-lang/crystal
 gh_clone crystal-lang/shards
 


### PR DESCRIPTION
crystal-db master has a breaking change which driver implementations don't support yet. So we need to pin it to the latest release.