### PR TITLE
putting back the llvm's config in env

### DIFF
--- a/.github/workflows/test-crystal-shards.yml
+++ b/.github/workflows/test-crystal-shards.yml
@@ -52,6 +52,7 @@ jobs:
 
           ./test-ecosystem/scripts/apt-install-tools.sh
           ./test-ecosystem/scripts/apt-install-llvm-libclang.sh
+          echo "LLVM_CONFIG=$LLVM_CONFIG" >> $GITHUB_ENV
           ./test-ecosystem/scripts/apt-install-crystal-deps.sh
           # for https://github.com/actions/checkout/issues/209
           apt-get install -y jq
@@ -194,6 +195,7 @@ jobs:
           apt-get update
           ./test-ecosystem/scripts/apt-install-tools.sh
           ./test-ecosystem/scripts/apt-install-llvm-libclang.sh
+          echo "LLVM_CONFIG=$LLVM_CONFIG" >> $GITHUB_ENV
           ./test-ecosystem/scripts/apt-install-crystal-deps.sh
           ./test-ecosystem/scripts/00-install-bats.sh
       - name: Initialize postgres


### PR DESCRIPTION
After #25 , the `LLVM_CONFIG` env was not saved in `GITHUB_ENV`. This is likely the failure in https://github.com/crystal-lang/test-ecosystem/runs/7219082247?check_suite_focus=true. This PR brings it back.