### PR TITLE
Add separate harness for simple tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      crystal_version:
+        type: string
+        default: nightly
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+          os: [ubuntu-22.04, windows-2022, macos-13]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ github.event.inputs.crystal_branch || 'latest' }}
+
+      - name: Setup BATS
+        uses: mig4/setup-bats@v1
+        with:
+          bats-version: 1.9.0
+
+      - name: Install dependencies
+        run: |
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            brew install pkg-config
+          fi
+
+      - name: Test
+        run: |
+          bats --pretty --timing test
+        env:
+          WINDOWS_BASE_DIR: "/d/a"
+          TERM: dumb

--- a/test/crystal.bats
+++ b/test/crystal.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+
+function setup_file() {
+  load helper/common.bash
+
+  git_checkout https://github.com/crystal-lang/crystal
+}
+
+function setup() {
+  load helper/common.bash
+}
+
+@test "$CRYSTAL --version" {
+  $CRYSTAL --version
+}
+
+@test "$CRYSTAL env" {
+  $CRYSTAL env
+}
+
+@test "crystal manual specs" {
+  "bin/crystal${BAT}" spec spec/manual/https_client_spec.cr
+}

--- a/test/helper/common.bash
+++ b/test/helper/common.bash
@@ -1,0 +1,40 @@
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/windows.bash"
+
+if [ -z "$BATS_TMPDIR" ]; then
+  export BATS_TMPDIR=${TEMP:-/tmp}/bats/
+  mkdir -p "$BATS_TMPDIR"
+fi
+
+EXE="${EXE:-}"
+CRYSTAL="${CRYSTAL:-crystal${EXE}}"
+SHARDS="${SHARDS:-shards${EXE}}"
+MAKE="${MAKE:-make${EXE}}"
+
+function git_checkout() {
+  local URL="$1"
+  local TARGET="$BATS_TMPDIR/${1##*/}"
+
+  if [ -d "$TARGET" ]; then
+    cd "$TARGET" || exit 1
+    git checkout --force origin/HEAD
+    git pull origin HEAD
+    git submodule update --init
+  else
+    git clone --recursive "$URL" "$TARGET"
+    cd "$TARGET" || exit 1
+  fi
+}
+
+function shard_checkout() {
+  git_checkout "$1"
+
+  # --skip-postinstall to prevent ameba building itself many times over
+  # --skip-executables is required with --skip-postinstall because postinstall
+  # executables are missing (https://github.com/crystal-lang/shards/issues/498).
+  $SHARDS install --skip-postinstall --skip-executables
+}
+
+function crystal_spec() {
+  $CRYSTAL spec --junit_output ".junit/interpreter-std_spec.$BATS_TEST_NAME.xml"
+}

--- a/test/helper/windows.bash
+++ b/test/helper/windows.bash
@@ -1,0 +1,36 @@
+nativepath() { echo "$1"; }
+nativevar() { eval export "$1"="$2"; }
+skiponwindows() { :; }
+
+IS_WINDOWS=${IS_WINDOWS:-false}
+WINDOWS_BASE_DIR=${WINDOWS_BASE_DIR:-/mnt/c}
+
+EXE=""
+BAT=""
+
+if [ "$RUNNER_OS" == "Windows" ] || [ "$IS_WINDOWS" == true ]; then
+  EXE=".exe"
+  BAT=".bat"
+
+  IS_WINDOWS=true
+  if [ ! -d "$WINDOWS_BASE_DIR"/batstmp ]; then
+    mkdir "$WINDOWS_BASE_DIR"/batstmp
+  fi
+
+  BATS_TMPDIR=$(TMPDIR="$WINDOWS_BASE_DIR"/batstmp mktemp -d -t bats-tests-XXXXXX)
+  export BATS_TMPDIR
+
+  nativepath() {
+    wslpath -w "$1"
+  }
+  nativevar() {
+    eval export "$1"="$2"
+    export WSLENV="$1$3"
+  }
+  skiponwindows() {
+    skip "$1 (Windows)"
+  }
+fi
+
+export EXE
+export BAT

--- a/test/libraries.bats
+++ b/test/libraries.bats
@@ -1,0 +1,231 @@
+#!/usr/bin/env bats
+
+# These tests cover some of the most popular Crystal libraries (shards),
+# identified via dependent counts on shardbox.org
+# They should require no special dependencies except some basic libraries
+# such as openssl.
+
+function setup() {
+  load 'helper/common.bash'
+}
+
+@test "Sija/backtracer.cr" {
+  skiponwindows "Specs are failing"
+  shard_checkout https://github.com/Sija/backtracer.cr
+
+  crystal_spec
+}
+
+# bats test_tags=openssl
+@test "crystal-loot/exception_page" {
+  skip "Specs are failing (https://github.com/crystal-loot/exception_page/issues/39)"
+  skiponwindows "Does not build"
+  shard_checkout https://github.com/crystal-loot/exception_page
+
+  crystal_spec
+}
+
+@test "luislavena/radix" {
+  shard_checkout https://github.com/luislavena/radix
+
+  crystal_spec
+}
+
+@test "ysbaddaden/pool" {
+  shard_checkout https://github.com/ysbaddaden/pool
+
+  crystal_spec
+}
+
+@test "luckyframework/habitat" {
+  shard_checkout https://github.com/luckyframework/habitat
+
+  crystal_spec
+}
+
+@test "luckyframework/wordsmith" {
+  shard_checkout https://github.com/luckyframework/wordsmith
+
+  crystal_spec
+}
+
+@test "crystal-community/future.cr" {
+  shard_checkout https://github.com/crystal-community/future.cr
+
+  crystal_spec
+}
+
+@test "schovi/baked_file_system" {
+  skiponwindows "Does not build"
+  shard_checkout https://github.com/schovi/baked_file_system
+
+  crystal_spec
+}
+
+@test "jeromegn/kilt" {
+  skiponwindows "Does not build"
+  shard_checkout https://github.com/jeromegn/kilt
+
+  crystal_spec
+}
+
+@test "sumpycr/stumpy_core" {
+  shard_checkout https://github.com/stumpycr/stumpy_core
+
+  crystal_spec
+}
+
+@test "luckyframework/lucky_task" {
+  shard_checkout https://github.com/luckyframework/lucky_task
+
+  crystal_spec
+}
+
+@test "spider-gazelle/bindata" {
+  shard_checkout https://github.com/spider-gazelle/bindata
+
+  crystal_spec
+}
+
+# bats test_tags=openssl
+@test "kemalcr/kemal-session" {
+  shard_checkout https://github.com/kemalcr/kemal-session
+
+  crystal_spec
+}
+
+# bats test_tags=openssl
+@test "kemalcr/kemal" {
+  if [[ "$(crystal env CRYSTAL_VERSION)" =~ ^0\.|^1\.[0-8]\. ]]; then
+    skiponwindows "Compiler bug in Crystal < 1.9"
+  fi
+
+  shard_checkout https://github.com/kemalcr/kemal
+
+  crystal_spec
+}
+
+@test "luckyframework/teeplate" {
+  skip "Wants to sign git commit"
+  skiponwindows "Does not build"
+  shard_checkout https://github.com/luckyframework/teeplate
+
+  crystal_spec
+}
+
+@test "icyleaf/markd" {
+  shard_checkout https://github.com/icyleaf/markd
+
+  crystal_spec
+}
+
+@test "crystal-lang/json_mapping.cr" {
+  skiponwindows "Does not build"
+  shard_checkout https://github.com/crystal-lang/json_mapping.cr
+
+  crystal_spec
+}
+
+@test "stumpycr/stumpy_png" {
+  skip "Incompatible with modern Crystal"
+  skiponwindows "Specs are failing"
+  shard_checkout https://github.com/stumpycr/stumpy_png
+
+  crystal_spec
+}
+
+@test "luckyframework/shell-table.cr" {
+  skip "Specs are failing"
+  shard_checkout https://github.com/luckyframework/shell-table.cr
+
+  crystal_spec
+}
+
+@test "phoffer/inflector.cr" {
+  skip "Specs are failing"
+  shard_checkout https://github.com/phoffer/inflector.cr
+
+  crystal_spec
+}
+
+# bats test_tags=cmake
+@test "kostya/lexbor" {
+  skiponwindows "Specs are failing"
+  shard_checkout https://github.com/kostya/lexbor
+
+  $CRYSTAL src/ext/build_ext.cr
+  crystal_spec
+}
+
+@test "icyleaf/halite" {
+  skiponwindows "Specs are failing"
+  shard_checkout https://github.com/icyleaf/halite
+
+  crystal_spec
+}
+
+@test "jwaldrip/admiral.cr" {
+  shard_checkout https://github.com/jwaldrip/admiral.cr
+
+  crystal_spec
+}
+
+@test "jeromegn/slang" {
+  if [[ "$(crystal env CRYSTAL_VERSION)" =~ ^0\.|^1\.[0-8]\. ]]; then
+    skiponwindows "Compiler bug in Crystal < 1.9"
+  fi
+
+  shard_checkout https://github.com/jeromegn/slang
+
+  crystal_spec
+}
+
+@test "vladfaust/time_format.cr" {
+  shard_checkout https://github.com/vladfaust/time_format.cr
+
+  crystal_spec
+}
+
+@test "mamantoha/http_proxy" {
+  skiponwindows "Specs are failing"
+  shard_checkout https://github.com/mamantoha/http_proxy
+
+  crystal_spec
+}
+
+@test "crystal-community/msgpack-crystal" {
+  shard_checkout https://github.com/crystal-community/msgpack-crystal
+
+  crystal_spec
+}
+
+@test "spider-gazelle/openssl_ext" {
+  skiponwindows "Specs are failing"
+  shard_checkout https://github.com/spider-gazelle/openssl_ext
+
+  crystal_spec
+}
+
+@test "gdotdesign/cr-dotenv" {
+  shard_checkout https://github.com/gdotdesign/cr-dotenv
+
+  crystal_spec
+}
+
+@test "maiha/pretty.cr" {
+  skip "Specs are failing"
+  shard_checkout https://github.com/maiha/pretty.cr
+
+  crystal_spec
+}
+
+@test "straight-shoota/crinja" {
+  skiponwindows "Specs are failing"
+
+  shard_checkout https://github.com/straight-shoota/crinja
+
+  crystal_spec
+
+  cd examples
+  bats integration_test.bats
+}

--- a/test/testing.bats
+++ b/test/testing.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+# These tests cover libraries for testing for Crystal projects.
+# They should require no special dependencies.
+
+function setup() {
+  load helper/common.bash
+}
+
+@test "ysbaddaden/minitest.cr" {
+  shard_checkout https://github.com/ysbaddaden/minitest.cr
+
+  crystal_spec
+}
+
+@test "arctic-fox/spectator" {
+  skip "Does not build"
+  shard_checkout https://gitlab.com/arctic-fox/spectator
+
+  crystal_spec
+}
+
+@test "crystal-community/timecop.cr" {
+  skiponwindows "Timeout"
+  shard_checkout https://github.com/crystal-community/timecop.cr
+
+  crystal_spec
+}
+
+@test "manastech/webmock.cr" {
+  skiponwindows "Specs are failing"
+  shard_checkout https://github.com/manastech/webmock.cr
+
+  crystal_spec
+}

--- a/test/tools.bats
+++ b/test/tools.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+# These tests cover applications that are used as tools for Crystal projects.
+
+function setup() {
+  load helper/common.bash
+}
+
+@test "crystal-ameba/ameba" {
+  skiponwindows "Timeout"
+  shard_checkout https://github.com/crystal-ameba/ameba
+
+  crystal_spec
+}


### PR DESCRIPTION
This adds in a bunch of portable tests for many Crystal libraries. The tests run on Linux, macOS and Windows via bats (Windows needs an environment with Unix tools).
A CI workflow runs the test on these three platforms.

This is a very basic implementation. It uses the `install-crystal` action and does not yet allow to use a custom compiler built. Also there are not yet any provisions for more complex dependencies, like databases required for testing db drivers. These will be added later using portable actions on GitHub CI.