### PR TITLE
Update CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-24.04, windows-2022, macos-13, macos-14]
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Updates to the latest CI images. Using both `macos-13` and `macos-14` because the former is x86_64 and the latter aarch64.

`macos-12` is being phased out.