### PR TITLE
Fix shard URL to gitlab.com

### DIFF
--- a/test/testing.bats
+++ b/test/testing.bats
@@ -27,7 +27,7 @@ function setup() {
 
 # bats test_tags=format
 @test "format arctic-fox/spectator" {
-  check_crystal_format https://github.com/arctic-fox/spectator
+  check_crystal_format https://gitlab.com/arctic-fox/spectator
 }
 
 @test "crystal-community/timecop.cr" {


### PR DESCRIPTION
Same as in the previous entry. Fixup for #55