### PR TITLE
Add OS-specific dependencies support to Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Configure git to not checkout CRLF
         run: git config --global --add core.autocrlf false
 
+      - name: Install OS-specific dependencies
+        run: bash ./setup/${{ matrix.os }}.bash
+
       - name: Test
         run: |
           bats --pretty --timing test --filter-tags !format

--- a/setup/macos-13.bash
+++ b/setup/macos-13.bash
@@ -1,1 +1,1 @@
-setup/macos-all.bash
+./macos-all.bash

--- a/setup/macos-13.bash
+++ b/setup/macos-13.bash
@@ -1,0 +1,1 @@
+setup/macos-all.bash

--- a/setup/macos-14.bash
+++ b/setup/macos-14.bash
@@ -1,1 +1,1 @@
-setup/macos-all.bash
+./macos-all.bash

--- a/setup/macos-14.bash
+++ b/setup/macos-14.bash
@@ -1,0 +1,1 @@
+setup/macos-all.bash

--- a/setup/macos-all.bash
+++ b/setup/macos-all.bash
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+brew install libmagic
+

--- a/setup/ubuntu-24.04.bash
+++ b/setup/ubuntu-24.04.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+apt-get update && \
+  apt-get install -y libmagic-dev && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
+

--- a/setup/ubuntu-24.04.bash
+++ b/setup/ubuntu-24.04.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-apt-get update && \
-  apt-get install -y libmagic-dev && \
-  apt-get clean && rm -rf /var/lib/apt/lists/*
+sudo apt-get update && \
+  sudo apt-get install -y libmagic-dev && \
+  sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 

--- a/setup/windows-2022.bash
+++ b/setup/windows-2022.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+choco install file


### PR DESCRIPTION
We introduce the ability to setup OS-level dependencies needed by the tested shards in the Github runners.